### PR TITLE
selectMenus typo fix

### DIFF
--- a/libs/containers/Components.lua
+++ b/libs/containers/Components.lua
@@ -356,7 +356,7 @@ function getter.buttons(self)
 end
 
 function getter.selectMenus(self)
-  return ArrayIterable(self._selfMenus)
+  return ArrayIterable(self._selectMenus)
 end
 
 return Components


### PR DESCRIPTION
selectMenus property not working due to typo